### PR TITLE
Use i3-sensible-terminal

### DIFF
--- a/tl-setup.sh
+++ b/tl-setup.sh
@@ -91,7 +91,7 @@ add_desktop_entry()
 	cat > ${entry_filename} <<- EOM
 [Desktop Entry]
 Encoding=UTF-8
-Exec=lxterminal -e "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY /usr/bin/java -jar -Dswing.systemlaf=javax.swing.plaf.nimbus.NimbusLookAndFeel ~/.minecraft/tlauncher.jar"
+Exec=i3-sensible-terminal -e "pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY /usr/bin/java -jar -Dswing.systemlaf=javax.swing.plaf.nimbus.NimbusLookAndFeel ~/.minecraft/tlauncher.jar"
 Icon=~/.minecraft/icons/default.png
 Type=Application
 Terminal=false


### PR DESCRIPTION
 There is no standard default terminal emulator. Use i3-sensible-terminal for flexibility across different Linux installations.